### PR TITLE
fix: ensure Descope middleware order

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ pip install django-descope
    ]
 ```
 
-3. Add Descope Middleware **after** the SessionMiddleware
+3. Add Descope Middleware **after** the AuthenticationMiddleware and SessionMiddleware
 
 ```
    MIDDLEWARE = [
    ...
    'django.contrib.sessions.middleware.SessionMiddleware',
+   'django.contrib.auth.middleware.AuthenticationMiddleware',
    ...
    'django_descope.middleware.DescopeMiddleware',
    ]

--- a/settings.py
+++ b/settings.py
@@ -60,10 +60,11 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # Add Descioe **after** Session & Authentication middleware
+    "django_descope.middleware.DescopeMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
-    "django_descope.middleware.DescopeMiddleware",  # <-- Add this **after** sessions middleware
 ]
 
 ROOT_URLCONF = "urls"

--- a/settings.py
+++ b/settings.py
@@ -60,7 +60,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    # Add Descioe **after** Session & Authentication middleware
+    # Add Descope **after** Session & Authentication middleware
     "django_descope.middleware.DescopeMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/django-descope/issues/147

## Description

AuthenticationMiddleware is obviously also required for DescopeMiddleware to work as it uses the `login` method.

This fixed documentation to highlight the change.