### PR TITLE
feat: expose descope sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,16 @@ pip install django-descope
 
 The following settings are available to configure in your project `settings.py`
 
+#### Required
+
 ```
-DESCOPE_PROJECT_ID **Required**
+DESCOPE_PROJECT_ID
+```
+
+#### Optional
+
+```
+DESCOPE_MANAGEMENT_KEY
 DESCOPE_IS_STAFF_ROLE
 DESCOPE_IS_SUPERUSER_ROLE
 ```

--- a/django_descope/__init__.py
+++ b/django_descope/__init__.py
@@ -1,3 +1,7 @@
-from .settings import descope_client
+from descope import DescopeClient
+
+from .settings import MANAGEMENT_KEY, PROJECT_ID
+
+descope_client = DescopeClient(project_id=PROJECT_ID, management_key=MANAGEMENT_KEY)
 
 all = [descope_client]

--- a/django_descope/__init__.py
+++ b/django_descope/__init__.py
@@ -1,0 +1,3 @@
+from .settings import descope_client
+
+all = [descope_client]

--- a/django_descope/authentication.py
+++ b/django_descope/authentication.py
@@ -1,6 +1,6 @@
 import logging
 
-from descope import REFRESH_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME
+from descope import REFRESH_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, SESSION_TOKEN_NAME
 from descope.exceptions import AuthException
 from django.conf import settings
 from django.contrib.auth import logout
@@ -46,7 +46,7 @@ class DescopeAuthentication(BaseBackend):
 
     def get_user(self, request: HttpRequest, validated_session, refresh_token):
         if validated_session:
-            username = validated_session.get("userId") or validated_session.get("sub")
+            username = validated_session[SESSION_TOKEN_NAME]["sub"]
             user, created = DescopeUser.objects.get_or_create(username=username)
             user.sync(validated_session, refresh_token)
             request.session[SESSION_COOKIE_NAME] = user.session_token["jwt"]

--- a/django_descope/authentication.py
+++ b/django_descope/authentication.py
@@ -7,8 +7,7 @@ from django.contrib.auth import logout
 from django.contrib.auth.backends import BaseBackend
 from django.http import HttpRequest
 
-from django_descope import descope_client
-
+from . import descope_client
 from .models import DescopeUser
 
 logger = logging.getLogger(__name__)

--- a/django_descope/authentication.py
+++ b/django_descope/authentication.py
@@ -2,6 +2,7 @@ import logging
 
 from descope import REFRESH_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, DescopeClient
 from descope.exceptions import AuthException
+from django.conf import settings
 from django.contrib.auth import logout
 from django.contrib.auth.backends import BaseBackend
 from django.http import HttpRequest
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class DescopeAuthentication(BaseBackend):
-    _dclient = DescopeClient(PROJECT_ID)
+    descope = DescopeClient(project_id=PROJECT_ID)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -23,12 +24,11 @@ class DescopeAuthentication(BaseBackend):
         refresh = request.session.get(REFRESH_SESSION_COOKIE_NAME)
 
         logger.debug("Validating (and refreshing) Descope session")
-        logger.debug("session %s", session)
-        logger.debug("refresh %s", refresh)
         try:
-            validated_token = self._dclient.validate_and_refresh_session(
+            validated_session = self.descope.validate_and_refresh_session(
                 session, refresh
             )
+
         except AuthException as e:
             """
             Ask forgiveness, not permission.
@@ -41,14 +41,16 @@ class DescopeAuthentication(BaseBackend):
             logout(request)
             return None
 
-        logger.debug(validated_token)
-        return self.get_user(request, validated_token, refresh)
+        if settings.DEBUG:
+            # Contains sensitive information, so only log in DEBUG mode
+            logger.debug(validated_session)
+        return self.get_user(request, validated_session, refresh)
 
-    def get_user(self, request: HttpRequest, validated_token=None, refresh_token=None):
-        if validated_token:
-            username = validated_token.get("userId") or validated_token.get("sub")
+    def get_user(self, request: HttpRequest, session=None, refresh=None):
+        if session:
+            username = session.get("userId") or session.get("sub")
             user, created = DescopeUser.objects.get_or_create(username=username)
-            user.sync(validated_token, refresh_token)
-            request.session[SESSION_COOKIE_NAME] = user.session
+            user.sync(session, refresh)
+            request.session[SESSION_COOKIE_NAME] = user.token
             return user
         return None

--- a/django_descope/models.py
+++ b/django_descope/models.py
@@ -3,9 +3,8 @@ import logging
 from descope import DescopeClient
 from django.contrib.auth import models as auth_models
 from django.core.cache import cache
-from django.utils.functional import cached_property
 
-from .settings import IS_STAFF_ROLE, IS_SUPERUSER_ROLE, PROJECT_ID
+from .settings import IS_STAFF_ROLE, IS_SUPERUSER_ROLE, MANAGEMENT_KEY, PROJECT_ID
 
 logger = logging.getLogger(__name__)
 
@@ -14,35 +13,33 @@ class DescopeUser(auth_models.User):
     class Meta:
         proxy = True
 
-    # User is always active since Descioe will never issue a token for an
+    # User is always active since Descope will never issue a token for an
     # inactive user
     is_active = True
-    _descope = DescopeClient(PROJECT_ID)
+    descope = DescopeClient(project_id=PROJECT_ID, management_key=MANAGEMENT_KEY)
 
     def sync(self, session, refresh):
-        self.token = session
-        self.session = session.get("jwt")
+        self.session = session
+        self.token = self.session["jwt"]
         self.refresh = refresh
-        self.user = session.get("user")
-        self.firstSeen = session.get("firstSeen")
+        self.firstSeen = self.session.get("firstSeen")
         self.username = self._me.get("userId")
+        self.user = self.username
         self.email = self._me.get("email")
-        self.is_staff = IS_STAFF_ROLE in self._roles
-        self.is_superuser = IS_SUPERUSER_ROLE in self._roles
+        self.is_staff = self.descope.validate_roles(self.session, [IS_STAFF_ROLE])
+        self.is_superuser = self.descope.validate_roles(
+            self.session, [IS_SUPERUSER_ROLE]
+        )
         self.save()
 
     def __str__(self):
         return f"DescopeUser {self.username}"
 
-    @cached_property
+    @property
     def _me(self):
         return cache.get_or_set(
-            f"descope_me:{self.username}", lambda: self._descope.me(self.refresh)
+            f"descope_me:{self.username}", lambda: self.descope.me(self.refresh)
         )
-
-    @cached_property
-    def _roles(self):
-        return self.token.get("roles", [])
 
     def get_username(self):
         return self.username

--- a/django_descope/models.py
+++ b/django_descope/models.py
@@ -1,5 +1,6 @@
 import logging
 
+from descope import SESSION_TOKEN_NAME
 from django.contrib.auth import models as auth_models
 from django.core.cache import cache
 
@@ -18,7 +19,7 @@ class DescopeUser(auth_models.User):
     is_active = True
 
     def sync(self, session, refresh):
-        self.session_token = session["sessionToken"]  # this should always exist
+        self.session_token = session[SESSION_TOKEN_NAME]  # this should always exist
         self.refresh_token = refresh
         self.username = self._me.get("userId")
         self.user = self.username

--- a/django_descope/models.py
+++ b/django_descope/models.py
@@ -3,7 +3,8 @@ import logging
 from django.contrib.auth import models as auth_models
 from django.core.cache import cache
 
-from .settings import IS_STAFF_ROLE, IS_SUPERUSER_ROLE, descope_client
+from . import descope_client
+from .settings import IS_STAFF_ROLE, IS_SUPERUSER_ROLE
 
 logger = logging.getLogger(__name__)
 

--- a/django_descope/models.py
+++ b/django_descope/models.py
@@ -1,10 +1,9 @@
 import logging
 
-from descope import DescopeClient
 from django.contrib.auth import models as auth_models
 from django.core.cache import cache
 
-from .settings import IS_STAFF_ROLE, IS_SUPERUSER_ROLE, MANAGEMENT_KEY, PROJECT_ID
+from .settings import IS_STAFF_ROLE, IS_SUPERUSER_ROLE, descope_client
 
 logger = logging.getLogger(__name__)
 
@@ -16,19 +15,18 @@ class DescopeUser(auth_models.User):
     # User is always active since Descope will never issue a token for an
     # inactive user
     is_active = True
-    descope = DescopeClient(project_id=PROJECT_ID, management_key=MANAGEMENT_KEY)
 
     def sync(self, session, refresh):
-        self.session = session
-        self.token = self.session["jwt"]
-        self.refresh = refresh
-        self.firstSeen = self.session.get("firstSeen")
+        self.session_token = session["sessionToken"]  # this should always exist
+        self.refresh_token = refresh
         self.username = self._me.get("userId")
         self.user = self.username
         self.email = self._me.get("email")
-        self.is_staff = self.descope.validate_roles(self.session, [IS_STAFF_ROLE])
-        self.is_superuser = self.descope.validate_roles(
-            self.session, [IS_SUPERUSER_ROLE]
+        self.is_staff = descope_client.validate_roles(
+            self.session_token, [IS_STAFF_ROLE]
+        )
+        self.is_superuser = descope_client.validate_roles(
+            self.session_token, [IS_SUPERUSER_ROLE]
         )
         self.save()
 
@@ -38,7 +36,7 @@ class DescopeUser(auth_models.User):
     @property
     def _me(self):
         return cache.get_or_set(
-            f"descope_me:{self.username}", lambda: self.descope.me(self.refresh)
+            f"descope_me:{self.username}", lambda: descope_client.me(self.refresh_token)
         )
 
     def get_username(self):

--- a/django_descope/settings.py
+++ b/django_descope/settings.py
@@ -1,4 +1,3 @@
-from descope import DescopeClient
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -14,5 +13,3 @@ if not PROJECT_ID:
 # Role names to create in Descope that will map to User attributes
 IS_STAFF_ROLE = getattr(settings, "DESCOPE_IS_STAFF_ROLE", "is_staff")
 IS_SUPERUSER_ROLE = getattr(settings, "DESCOPE_IS_SUPERUSER_ROLE", "is_superuser")
-
-descope_client = DescopeClient(project_id=PROJECT_ID, management_key=MANAGEMENT_KEY)

--- a/django_descope/settings.py
+++ b/django_descope/settings.py
@@ -1,3 +1,4 @@
+from descope import DescopeClient
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -13,3 +14,5 @@ if not PROJECT_ID:
 # Role names to create in Descope that will map to User attributes
 IS_STAFF_ROLE = getattr(settings, "DESCOPE_IS_STAFF_ROLE", "is_staff")
 IS_SUPERUSER_ROLE = getattr(settings, "DESCOPE_IS_SUPERUSER_ROLE", "is_superuser")
+
+descope_client = DescopeClient(project_id=PROJECT_ID, management_key=MANAGEMENT_KEY)

--- a/django_descope/settings.py
+++ b/django_descope/settings.py
@@ -5,6 +5,7 @@ WEB_COMPONENT_SRC = getattr(
     settings, "DESCOPE_WEB_COMPONENT_SRC", "https://unpkg.com/@descope/web-component"
 )
 
+MANAGEMENT_KEY = getattr(settings, "DESCOPE_MANAGEMENT_KEY", None)
 PROJECT_ID = getattr(settings, "DESCOPE_PROJECT_ID", None)
 if not PROJECT_ID:
     raise ImproperlyConfigured('"DESCOPE_PROJECT_ID" is required!')

--- a/django_descope/views.py
+++ b/django_descope/views.py
@@ -1,17 +1,13 @@
 import logging
 
-from descope import REFRESH_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME, DescopeClient
+from descope import REFRESH_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME
 from django.http import HttpRequest, HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.cache import never_cache
 
-from . import settings
-
 # User = get_user_model()
 logger = logging.getLogger(__name__)
-
-descope_client = DescopeClient(project_id=settings.PROJECT_ID)
 
 
 @method_decorator([never_cache], name="dispatch")

--- a/example_app/templates/descope_login.html
+++ b/example_app/templates/descope_login.html
@@ -12,6 +12,7 @@
   <body>
     {% if user.is_authenticated %}
     <h1>Welcome {{ user.email }} you are logged in!</h1>
+    <p><a href="{% url 'debug' %}">Detailed user information</a></p>
     <p><a href="{% url 'logout' %}">Log Out</a></p>
     {% else %}
       {% descope_flow "sign-up-or-in" "/" %}

--- a/example_app/urls.py
+++ b/example_app/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 from django.views.generic import TemplateView
 
-from .views import Index
+from .views import Debug
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="descope_login.html"), name="index"),
-    path("test", Index.as_view(), name="test"),
+    path("debug", Debug.as_view(), name="debug"),
 ]

--- a/example_app/views.py
+++ b/example_app/views.py
@@ -5,6 +5,7 @@ from django.http import HttpRequest, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.views import View
 
+from django_descope import descope_client
 from django_descope.models import DescopeUser
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,13 @@ class Logout(View):
 class Debug(View):
     def get(self, request: HttpRequest):
         logger.info("Debug view called")
+        mgmt = False
+        try:
+            descope_client.mgmt
+            mgmt = True
+        except Exception:
+            pass
+
         return JsonResponse(
             {
                 "user": request.user.username,
@@ -26,7 +34,8 @@ class Debug(View):
                 "is_staff": request.user.is_staff,
                 "is_superuser": request.user.is_superuser,
                 "email": request.user.email,
-                "session": request.user.session,
+                "session": request.user.session_token,
+                "is_mgmt_available": mgmt,
             }
             if isinstance(request.user, DescopeUser)
             else {

--- a/example_app/views.py
+++ b/example_app/views.py
@@ -5,6 +5,8 @@ from django.http import HttpRequest, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.views import View
 
+from django_descope.models import DescopeUser
+
 logger = logging.getLogger(__name__)
 
 
@@ -14,9 +16,9 @@ class Logout(View):
         return HttpResponseRedirect(reverse("index"))
 
 
-class Index(View):
+class Debug(View):
     def get(self, request: HttpRequest):
-        logger.info("Index view called")
+        logger.info("Debug view called")
         return JsonResponse(
             {
                 "user": request.user.username,
@@ -24,5 +26,12 @@ class Index(View):
                 "is_staff": request.user.is_staff,
                 "is_superuser": request.user.is_superuser,
                 "email": request.user.email,
+                "session": request.user.session,
+            }
+            if isinstance(request.user, DescopeUser)
+            else {
+                "is_authenticated": request.user.is_authenticated,
+                "is_anonymous": request.user.is_anonymous,
+                "is_active": request.user.is_active,
             }
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -408,13 +408,13 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.1"
+version = "4.2.2"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.2.1-py3-none-any.whl", hash = "sha256:066b6debb5ac335458d2a713ed995570536c8b59a580005acb0732378d5eb1ee"},
-    {file = "Django-4.2.1.tar.gz", hash = "sha256:7efa6b1f781a6119a10ac94b4794ded90db8accbe7802281cd26f8664ffed59c"},
+    {file = "Django-4.2.2-py3-none-any.whl", hash = "sha256:672b3fa81e1f853bb58be1b51754108ab4ffa12a77c06db86aa8df9ed0c46fe5"},
+    {file = "Django-4.2.2.tar.gz", hash = "sha256:2a6b6fbff5b59dd07bef10bcb019bee2ea97a30b2a656d51346596724324badf"},
 ]
 
 [package.dependencies]
@@ -479,18 +479,18 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "filelock"
-version = "3.12.0"
+version = "3.12.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "filelock-3.12.0-py3-none-any.whl", hash = "sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9"},
-    {file = "filelock-3.12.0.tar.gz", hash = "sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"},
+    {file = "filelock-3.12.1-py3-none-any.whl", hash = "sha256:42f1e4ff2b497311213d61ad7aac5fed9050608e5309573f101eefa94143134a"},
+    {file = "filelock-3.12.1.tar.gz", hash = "sha256:82b1f7da46f0ae42abf1bc78e548667f484ac59d2bcec38c713cee7e2eb51e83"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "flake8"
@@ -626,18 +626,18 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.5.1"
+version = "3.5.3"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
-    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
+    {file = "platformdirs-3.5.3-py3-none-any.whl", hash = "sha256:0ade98a4895e87dc51d47151f7d2ec290365a585151d97b4d8d6312ed6132fed"},
+    {file = "platformdirs-3.5.3.tar.gz", hash = "sha256:e48fabd87db8f3a7df7150a4a5ea22c546ee8bc39bc2473244730d4b56d2cc4e"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -948,13 +948,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "2.0.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
+    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/django-descope/issues/152

## Description

* Add an optional setting to allow using [Descope SDK Management API](https://docs.descope.com/manage/)
* Expose a reusable `descope` client on top level of module
* Fix role validation to use Descope SDK
