### PR TITLE
feat: support Django 6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: ["3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2", "main"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2", "6.0", "main"]
         exclude:
           - python-version: "3.9"
             django-version: "main"
           - python-version: "3.9"
             django-version: "5.0"
+          # Django 6.0 requires Python 3.12+
+          - python-version: "3.9"
+            django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.0"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/django_descope/test_templatetags.py
+++ b/django_descope/test_templatetags.py
@@ -1,0 +1,59 @@
+import logging
+
+from django.template import Context
+from django.test import RequestFactory, TestCase, override_settings
+from django.utils.safestring import SafeString
+
+from django_descope.templatetags.descope import CONTEXT_KEY, descope_flow
+
+logger = logging.getLogger(__name__)
+
+TEST_PROJECT_ID = "P2TestProjectId0000000000000000"
+
+
+@override_settings(ROOT_URLCONF="urls", DESCOPE_PROJECT_ID=TEST_PROJECT_ID)
+class DescopeFlowTagTestCase(TestCase):
+    """Offline tests for the ``descope_flow`` template tag.
+
+    These exercise Django template, CSRF, URL reversing and safestring APIs
+    without any network calls to Descope, so they run under every supported
+    Django version (including Django 6.0).
+    """
+
+    def _context(self):
+        context = Context({})
+        # ``descope_flow`` takes_context and reads ``context.request``.
+        context.request = RequestFactory().get("/")
+        return context
+
+    def test_returns_marked_safe_html(self):
+        """The tag output must be marked safe so it is not auto-escaped."""
+        html = descope_flow(self._context(), "sign-up-or-in", "/")
+        self.assertIsInstance(html, SafeString)
+
+    def test_renders_web_component_and_flow(self):
+        """The rendered markup includes the web component and the flow config."""
+        html = descope_flow(self._context(), "sign-up-or-in", "/")
+
+        # Web component script is included on first render.
+        self.assertIn("@descope/web-component@", html)
+        # The flow element is rendered with the configured project and flow id.
+        self.assertIn("<descope-wc", html)
+        self.assertIn(f'project-id="{TEST_PROJECT_ID}"', html)
+        self.assertIn('flow-id="sign-up-or-in"', html)
+        # The success handler posts back to the namespaced store_jwt URL.
+        self.assertIn("/auth/store_jwt", html)
+
+    def test_web_component_included_only_once_per_context(self):
+        """Reusing the same context must not inject the script tag twice."""
+        context = self._context()
+
+        first = descope_flow(context, "sign-up-or-in", "/")
+        self.assertIn("@descope/web-component@", first)
+        self.assertTrue(context.get(CONTEXT_KEY))
+
+        second = descope_flow(context, "another-flow", "/")
+        # Script tag is only emitted on the first render for a given context.
+        self.assertNotIn("<script src=", second)
+        # ...but the flow element is still rendered.
+        self.assertIn('flow-id="another-flow"', second)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -42,7 +43,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "Django>=3.2.25,<5.3",
+    "Django>=3.2.25,<6.1",
     "descope>=1.5.1,<2",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-isolated_build=true
 envlist=
     py3{8,9,10}-dj{32,40,41,42}
     py31{1,2,3}-dj{42, 50, 51, 52}
@@ -29,8 +28,6 @@ DJANGO=
 [testenv]
 commands =
     python manage.py test
-extras=
-    test
 passenv=
     DESCOPE_PROJECT_ID
     DESCOPE_MANAGEMENT_KEY

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ isolated_build=true
 envlist=
     py3{8,9,10}-dj{32,40,41,42}
     py31{1,2,3}-dj{42, 50, 51, 52}
+    py31{2,3,4}-dj60
 
 [gh-actions]
 python=
@@ -11,6 +12,7 @@ python=
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 DJANGO=
@@ -21,6 +23,7 @@ DJANGO=
     5.0: dj50
     5.1: dj51
     5.2: dj52
+    6.0: dj60
     main: djmain
 
 [testenv]
@@ -41,6 +44,7 @@ deps=
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
+    dj60: Django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     python-dotenv
     django-debug-toolbar


### PR DESCRIPTION
**Support Django 6.0**
Adds Django 6.0 to the list of supported and tested Django versions.

**Background**
Django 6.0 introduces no backwards-incompatible changes that affect this SDK. I verified the codebase against the [Django 6.0 release notes](https://docs.djangoproject.com/en/6.0/releases/6.0/):

No removed/renamed APIs are used (no positional Model.save() args, no format_html() without args, no ChoicesMeta, etc.).
MiddlewareMixin, proxy models, mark_safe, get_random_string, JsonResponse, and CSRF/session handling are all unchanged in 6.0.
DEFAULT_AUTO_FIELD is already set to BigAutoField (the new 6.0 default), so no migration churn.
Because Django 6.0 drops support for Python 3.10 and 3.11, the 6.0 test entries only run on Python 3.12–3.14.

**Changes**
pyproject.toml
Widen the Django dependency ceiling: Django>=3.2.25,<5.3 → Django>=3.2.25,<6.1
Add the Framework :: Django :: 6.0 trove classifier
tox.ini
Add a dj60 environment (Django>=6.0,<6.1) for Python 3.12–3.14
Add the 6.0 → dj60 and 3.14 → py314 gh-actions mappings
.github/workflows/ci.yaml
Add 6.0 and Python 3.14 to the CI matrix
Exclude Python 3.9/3.10/3.11 × Django 6.0 (unsupported combinations)
django_descope/test_templatetags.py (new)
Offline tests for the descope_flow template tag covering template rendering, the web-component injection, CSRF token embedding, namespaced URL reversing, SafeString output, and the "script included once per context" behavior. These require no Descope network calls, so they run in every matrix cell — including Django 6.0.
Verification
In an isolated Python 3.12 + Django 6.0.7 environment:

✅ All migrations apply and the DescopeUser proxy model loads
✅ manage.py check reports no issues
✅ All new template-tag tests pass
✅ Every django_descope module imports cleanly with deprecation warnings promoted to errors (no RemovedInDjango*Warning)