### PR TITLE
ci: update uv lock in release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,13 @@
       "package-name": "django-descope",
       "changelog-path": "CHANGELOG.md",
       "release-type": "python",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='django-descope')].version"
+        }
+      ],
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false
     }


### PR DESCRIPTION
## Summary
- configure release-please to bump django-descope's uv.lock package version
- use the documented GenericToml JSONPath workaround for uv lock packages

## Why
Release PR [#410](https://github.com/descope/django-descope/pull/410) failed every locked uv job because pyproject.toml was bumped to 3.0.0 while uv.lock still carried the old editable package version.

References:
- [googleapis/release-please#2561](https://github.com/googleapis/release-please/issues/2561)
- [googleapis/release-please#2455 comment](https://github.com/googleapis/release-please/issues/2455#issuecomment-2643132770)

## Verification
- jq . release-please-config.json
- uv lock --check
- uv sync --locked --python 3.14
- uv run ruff check .
- uv run ruff format --check .
- uv run licensecheck --groups dev --zero
- uv build
- DESCOPE_PROJECT_ID=... uv run --locked --python 3.9 --with "Django>=3.2.25,<3.3" --with python-dotenv --with django-debug-toolbar python manage.py check